### PR TITLE
feat: set outline none for buttons

### DIFF
--- a/frontend/src/views/Projects.vue
+++ b/frontend/src/views/Projects.vue
@@ -79,6 +79,14 @@ export default {
   }
 }
 </script>
+
+<style>
+/* global scope for override v-btn styles */
+button.v-btn, button.v-expansion-panel-header {
+  outline: none
+}
+</style>
+
 <style scoped>
 .header {
     color: white;


### PR DESCRIPTION
### Description
Set Outline to none for buttons ( v-btn and v-expansion-panels buttons )

Fixes #52 

### Type of Change:
- User Interface

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation/ readme file
- [x] Any dependent changes have been merged 
